### PR TITLE
Superfluous Debug message

### DIFF
--- a/osquery.go
+++ b/osquery.go
@@ -29,7 +29,6 @@
 package osquery
 
 import (
-	"fmt"
 	"os/exec"
 	"runtime"
 	"strings"

--- a/osquery.go
+++ b/osquery.go
@@ -164,7 +164,6 @@ func getWindows() (*OSInfo, error) {
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("%#v\n", string(out))
 
 	params := parseKeyValueList(string(out))
 


### PR DESCRIPTION
Useful library, good work!

This debug message was probably left in by mistake. It screws usage of the library on windows, because it outputs to stdout (when it shouldn't output at all).